### PR TITLE
skip port in URL when port==80

### DIFF
--- a/oceandb_bigchaindb_driver/instance.py
+++ b/oceandb_bigchaindb_driver/instance.py
@@ -24,7 +24,10 @@ class BigchainDBInstance(object):
         port = int(get_value('db.port', 'DB_PORT', 9984, config))
         app_id = get_value('db.app_id', 'DB_APP_ID', None, config)
         app_key = get_value('db.app_key', 'DB_APP_KEY', None, config)
-        bdb_root_url = '%s://%s:%s' % (scheme, host, port)
+        if port == 80:
+            bdb_root_url = '%s://%s' % (scheme, host)
+        else:
+            bdb_root_url = '%s://%s:%s' % (scheme, host, port)
         tokens = {'app_id': app_id, 'app_key': app_key}
 
         self._bdb = BigchainDB(bdb_root_url, headers=tokens)


### PR DESCRIPTION
## Description

Public urls besides `localhost` don't want a port in the connection 
e.g.
`localhost:9984/api/v2`
vs
`https://test.bigchaindb.com/api/v2`

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->](https://media.giphy.com/media/M5bRObgwkB9u0/giphy.gif)