### PR TITLE
Remove all mentions of BDB app_id and app_key

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,12 @@
 [bumpversion]
 current_version = 0.1.4
-
-[bumpversion:file:setup.cfg]
+commit = True
+tag = True
 
 [bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'
 
+[bumpversion:file:oceandb-bigchaindb-driver/__init__.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
 
-lint: ## check style with flake8
-	flake8 oceandb-bigchaindb-driver tests
+lint: ## check style with PyLint
+	pylint --errors-only oceandb_bigchaindb_driver tests
 
 test: ## run tests quickly with the default Python
 	py.test
@@ -64,17 +64,6 @@ coverage: ## check code coverage quickly with the default Python
 	coverage report -m
 	coverage html
 	$(BROWSER) htmlcov/index.html
-
-docs: ## generate Sphinx HTML documentation, including API docs
-	rm -f docs/oceandb-bigchaindb-driver.rst
-	rm -f docs/modules.rst
-	sphinx-apidoc -o docs/ oceandb-bigchaindb-driver
-	$(MAKE) -C docs clean
-	$(MAKE) -C docs html
-	$(BROWSER) docs/_build/html/index.html
-
-servedocs: docs ## compile the docs watching for changes
-	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
 
 release: dist ## package and upload a release
 	twine upload dist/*

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - mongodb
       - tendermint
-    image: bigchaindb/bigchaindb:2.0.0-beta5
+    image: bigchaindb/bigchaindb:2.0.0-beta9
     environment:
       BIGCHAINDB_DATABASE_BACKEND: localmongodb
       BIGCHAINDB_DATABASE_HOST: mongodb

--- a/oceandb_bigchaindb_driver/instance.py
+++ b/oceandb_bigchaindb_driver/instance.py
@@ -22,10 +22,8 @@ class BigchainDBInstance(object):
         scheme = get_value('db.scheme', 'DB_SCHEME', 'http', config)
         host = get_value('db.hostname', 'DB_HOSTNAME', 'localhost', config)
         port = int(get_value('db.port', 'DB_PORT', 9984, config))
-        app_id = get_value('db.app_id', 'DB_APP_ID', None, config)
-        app_key = get_value('db.app_key', 'DB_APP_KEY', None, config)
         bdb_root_url = '%s://%s:%s' % (scheme, host, port)
-        tokens = {'app_id': app_id, 'app_key': app_key}
+        tokens = {}
 
         self._bdb = BigchainDB(bdb_root_url, headers=tokens)
 

--- a/oceandb_bigchaindb_driver/plugin.py
+++ b/oceandb_bigchaindb_driver/plugin.py
@@ -64,7 +64,7 @@ class Plugin(AbstractPlugin):
             private_keys=self.user.private_key
         )
         self.logger.debug('bdb::write::{}'.format(signed_tx['id']))
-        self.driver.instance.transactions.send(signed_tx)
+        self.driver.instance.transactions.send_commit(signed_tx)
         return signed_tx
 
     def read(self, resource_id):
@@ -235,7 +235,7 @@ class Plugin(AbstractPlugin):
             prepared_transfer_tx,
             private_keys=self.user.private_key,
         )
-        self.driver.instance.transactions.send(signed_tx)
+        self.driver.instance.transactions.send_commit(signed_tx)
 
     def get_asset_id(self, tx_id):
         """Return the tx_id of the first transaction.
@@ -275,7 +275,7 @@ class Plugin(AbstractPlugin):
             prepared_transfer_tx,
             private_keys=self.user.private_key,
         )
-        self.driver.instance.transactions.send(signed_tx)
+        self.driver.instance.transactions.send_commit(signed_tx)
         return signed_tx
 
     def _find_tx_id(self, resource_id):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,18 +1,1 @@
-pip==9.0.1
-bumpversion==0.5.3
-wheel==0.31.0
-watchdog==0.8.3
-flake8==3.5.0
-#Using this version until 0.5.0 is stable
-bigchaindb_driver==0.5.0a2
-BigchainDB==2.0.0a2
-tox==2.9.1
-coverage==4.5.1
-oceandb-driver-interface==0.1.11
-singletonify==0.1.2.0
-Sphinx==1.7.1
-twine==1.11.0
-setuptools==39.1.0
-codacy-coverage
-pytest==3.4.2
-pytest-runner==2.11.1
+-e .[dev]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,21 +1,5 @@
-[bumpversion]
-current_version = 0.1.4
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:oceandb-bigchaindb-driver/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bdist_wheel]
 universal = 1
-
-[flake8]
-exclude = docs
 
 [aliases]
 # Define setup.py command aliases here
@@ -23,4 +7,3 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,30 @@ with open('README.md') as readme_file:
 with open('CHANGELOG.md') as changelog_file:
     changelog = changelog_file.read()
 
-requirements = ['oceandb-driver-interface', 'bigchaindb_driver', 'BigchainDB', ]
+install_requirements = [
+    'bigchaindb_driver',
+    'bigchaindb==2.0.0b9',
+    'oceandb-driver-interface',
+    'singletonify',
+]
 
 setup_requirements = ['pytest-runner', ]
 
-test_requirements = ['pytest', ]
+dev_requirements = [
+    'bumpversion',
+    'pkginfo',
+    'twine',
+    'watchdog',
+]
+
+test_requirements = [
+    'codacy-coverage',
+    'coverage',
+    'mccabe',
+    'pylint',
+    'pytest',
+    'tox',
+]
 
 setup(
     author="leucothia",
@@ -29,7 +48,11 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     description="🐳 Ocean DB BigchainDB driver (Python).",
-    install_requires=requirements,
+    extras_require={
+        'test': test_requirements,
+        'dev': dev_requirements + test_requirements,
+    },
+    install_requires=install_requirements,
     license="Apache Software License 2.0",
     long_description=readme + '\n\n' + changelog,
     long_description_content_type='text/x-rst',

--- a/tests/oceandb.ini
+++ b/tests/oceandb.ini
@@ -9,7 +9,3 @@ db.scheme=http
 db.hostname=localhost
 db.port=9984
 db.namespace=namespace1
-db.app_id=
-db.app_key=
-
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,10 @@
 [tox]
-envlist = py36, flake8
+envlist = py36, py37
 
 [travis]
 python =
     3.6: py36
-
-[testenv:flake8]
-basepython = python
-deps = flake8
-commands = flake8 oceandb-bigchaindb-driver
+    3.7: py37
 
 [testenv]
 passenv = CODACY_PROJECT_TOKEN
@@ -25,5 +21,3 @@ commands =
     coverage report
     coverage xml
     python-codacy-coverage -r coverage.xml
-
-


### PR DESCRIPTION
The BigchainDB Testnet used to require an app_id and app_key in the HTTP request header, but it doesn't anymore, so we can remove all mentions of those.

I created this PR as a follow-up to https://github.com/oceanprotocol/aquarius/pull/141 but I guess this PR should be merged first?